### PR TITLE
*NOT WORKING* Try to upgrade dependencies

### DIFF
--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -9,16 +9,16 @@ repository = "https://github.com/RustCrypto/password-hashing"
 keywords = ["crypto", "password", "hashing"]
 
 [dependencies]
-crypto-mac = "0.4"
-generic-array = "0.8"
+crypto-mac = "0.6"
+generic-array = "0.9"
 byte-tools = "0.2"
 
 rayon = { version = "0.8", optional = true }
 
 [dev-dependencies]
-hmac = "0.4"
-sha-1 = "0.4"
-sha2 = "0.6"
+hmac = "0.5"
+sha-1 = "0.7"
+sha2 = "0.7"
 
 [features]
 parallel = ["rayon"]

--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -13,10 +13,10 @@ crypto-mac = "0.6"
 generic-array = "0.9"
 byte-tools = "0.2"
 
-rayon = { version = "0.8", optional = true }
+rayon = { version = "1", optional = true }
 
 [dev-dependencies]
-hmac = "0.5"
+hmac = "0.6"
 sha-1 = "0.7"
 sha2 = "0.7"
 

--- a/pbkdf2/tests/lib.rs
+++ b/pbkdf2/tests/lib.rs
@@ -1,8 +1,8 @@
 extern crate pbkdf2;
-extern crate sha_1;
+extern crate sha1;
 extern crate hmac;
 
-use sha_1::Sha1;
+use sha1::Sha1;
 use hmac::Hmac;
 
 #[derive(Debug)]


### PR DESCRIPTION
Hi, I have a try to update the dependencies to the new versions but I got to a point here I would need your opinion.
When I compile it with these changes this will be the result.

```
error[E0382]: use of moved value: `salt`
  --> pbkdf2\src\lib.rs:41:9
   |
40 |         xor(chunk, &salt.code());
   |                     ---- value moved here
41 |         salt
   |         ^^^^ value used here after move
   |
   = note: move occurs because `salt` has type `crypto_mac::MacResult<<F as crypto_mac::Mac>::OutputSize>`, which does not implement the `Copy` trait
```
Looks like that code returns a generic array and takes self as exclusive owner. Reading the docs I found this [1], what do you think of using clone_from? But to using I would have to create a new MacResult from an empty GenericArray and use it to make the xor call.
These changes are necessary otherwise pbkdf2 won't work with new crypto_mac and hashes libraries.
Let me know and I can make the change on my side. Thank you!

[1] https://docs.rs/crypto-mac/0.6.0/crypto_mac/struct.MacResult.html#impl-Clone