### PR TITLE
Port utility functions for pbkdf2 from rust-crypto

### DIFF
--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -15,10 +15,18 @@ byte-tools = "0.2"
 
 rayon = { version = "1", optional = true }
 
+constant_time_eq = { version = "0.1", optional = true }
+base64 = { version = "0.9", optional = true }
+rand = { version = "0.5", optional = true }
+hmac = { version = "0.6", optional = true }
+sha2 = { version = "0.7", optional = true }
+
 [dev-dependencies]
 hmac = "0.6"
 sha-1 = "0.7"
 sha2 = "0.7"
 
 [features]
+default = ["include_simple"]
 parallel = ["rayon"]
+include_simple = ["sha2", "hmac", "rand", "base64", "constant_time_eq"]

--- a/pbkdf2/src/errors.rs
+++ b/pbkdf2/src/errors.rs
@@ -1,0 +1,28 @@
+use std::{fmt, error};
+
+#[cfg(feature="include_simple")]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum CheckError {
+    HashMismatch,
+    InvalidFormat,
+}
+
+#[cfg(feature="include_simple")]
+impl fmt::Display for CheckError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(match self {
+            CheckError::HashMismatch => "password hash mismatch",
+            CheckError::InvalidFormat => "invalid `hashed_value` format",
+        })
+    }
+}
+
+#[cfg(feature="include_simple")]
+impl error::Error for CheckError {
+    fn description(&self) -> &str {
+        match self {
+            CheckError::HashMismatch => "password hash mismatch",
+            CheckError::InvalidFormat => "invalid `hashed_value` format",
+        }
+    }
+}

--- a/pbkdf2/src/lib.rs
+++ b/pbkdf2/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "include_simple"), no_std)]
 #![cfg_attr(feature = "cargo-clippy", allow(inline_always))]
 extern crate crypto_mac;
 extern crate generic_array;
@@ -12,6 +12,31 @@ use rayon::prelude::*;
 use crypto_mac::Mac;
 use generic_array::typenum::Unsigned;
 use byte_tools::write_u32_be;
+
+#[cfg(feature="include_simple")]
+extern crate constant_time_eq;
+#[cfg(feature="include_simple")]
+extern crate base64;
+#[cfg(feature="include_simple")]
+extern crate rand;
+#[cfg(feature="include_simple")]
+extern crate hmac;
+#[cfg(feature="include_simple")]
+extern crate sha2;
+
+#[cfg(feature="include_simple")]
+use std::io;
+
+#[cfg(feature="include_simple")]
+use byte_tools::read_u32_be;
+#[cfg(feature="include_simple")]
+use constant_time_eq::constant_time_eq;
+#[cfg(feature="include_simple")]
+use rand::{OsRng, RngCore};
+#[cfg(feature="include_simple")]
+use hmac::Hmac;
+#[cfg(feature="include_simple")]
+use sha2::Sha256;
 
 #[inline(always)]
 fn xor(res: &mut [u8], salt: &[u8]) {
@@ -73,4 +98,141 @@ pub fn pbkdf2<F>(password: &[u8], salt: &[u8], c: usize, res: &mut [u8])
     for (i, chunk) in res.chunks_mut(n).enumerate() {
         pbkdf2_body(i, chunk, &prf, salt, c);
     }
+}
+
+/**
+ * pbkdf2_simple is a helper function that should be sufficient for the majority of cases where
+ * an application needs to use PBKDF2 to hash a password for storage. The result is a String that
+ * contains the parameters used as part of its encoding. The pbkdf2_check function may be used on
+ * a password to check if it is equal to a hashed value.
+ *
+ * # Format
+ *
+ * The format of the output is a modified version of the Modular Crypt Format that encodes algorithm
+ * used and iteration count. The format is indicated as "rpbkdf2" which is short for "Rust PBKF2
+ * format."
+ *
+ * $rpbkdf2$0$<base64(c)>$<base64(salt)>$<based64(hash)>$
+ *
+ * # Arguments
+ *
+ * * password - The password to process as a str
+ * * c - The iteration count
+ *
+ */
+#[cfg(feature="include_simple")]
+pub fn pbkdf2_simple(password: &str, c: u32) -> io::Result<String> {
+    let mut rng = OsRng::new()?;
+
+    // 128-bit salt
+    let mut salt = [0u8; 16];
+    rng.try_fill_bytes(&mut salt)?;
+
+    // 256-bit derived key
+    let mut dk = [0u8; 32];
+
+    pbkdf2::<Hmac<Sha256>>(password.as_bytes(), &salt, c as usize, &mut dk);
+
+    let mut result = "$rpbkdf2$0$".to_string();
+    let mut tmp = [0u8; 4];
+    write_u32_be(&mut tmp, c);
+    result.push_str(&base64::encode(&tmp));
+    result.push('$');
+    result.push_str(&base64::encode(&salt));
+    result.push('$');
+    result.push_str(&base64::encode(&dk));
+    result.push('$');
+
+    Ok(result)
+}
+
+/**
+ * pbkdf2_check compares a password against the result of a previous call to pbkdf2_simple and
+ * returns true if the passed in password hashes to the same value.
+ *
+ * # Arguments
+ *
+ * * password - The password to process as a str
+ * * hashed_value - A string representing a hashed password returned by pbkdf2_simple()
+ *
+ */
+#[cfg(feature="include_simple")]
+pub fn pbkdf2_check(password: &str, hashed_value: &str) -> Result<bool, &'static str> {
+    static ERR_STR: &'static str = "Hash is not in Rust PBKDF2 format.";
+
+    let mut iter = hashed_value.split('$');
+
+    // Check that there are no characters before the first "$"
+    match iter.next() {
+        Some(x) => if x != "" { return Err(ERR_STR); },
+        None => return Err(ERR_STR)
+    }
+
+    // Check the name
+    match iter.next() {
+        Some(t) => if t != "rpbkdf2" { return Err(ERR_STR); },
+        None => return Err(ERR_STR)
+    }
+
+    // Parse format - currenlty only version 0 is supported
+    match iter.next() {
+        Some(fstr) => {
+            match fstr {
+                "0" => { }
+                _ => return Err(ERR_STR)
+            }
+        }
+        None => return Err(ERR_STR)
+    }
+
+    // Parse the iteration count
+    let c = match iter.next() {
+        Some(pstr) => match base64::decode(pstr) {
+            Ok(pvec) => {
+                if pvec.len() != 4 { return Err(ERR_STR); }
+                read_u32_be(&pvec[..])
+            }
+            Err(_) => return Err(ERR_STR)
+        },
+        None => return Err(ERR_STR)
+    };
+
+    // Salt
+    let salt = match iter.next() {
+        Some(sstr) => match base64::decode(sstr) {
+            Ok(salt) => salt,
+            Err(_) => return Err(ERR_STR)
+        },
+        None => return Err(ERR_STR)
+    };
+
+    // Hashed value
+    let hash = match iter.next() {
+        Some(hstr) => match base64::decode(hstr) {
+            Ok(hash) => hash,
+            Err(_) => return Err(ERR_STR)
+        },
+        None => return Err(ERR_STR)
+    };
+
+    // Make sure that the input ends with a "$"
+    match iter.next() {
+        Some(x) => if x != "" { return Err(ERR_STR); },
+        None => return Err(ERR_STR)
+    }
+
+    // Make sure there is no trailing data after the final "$"
+    match iter.next() {
+        Some(_) => return Err(ERR_STR),
+        None => { }
+    }
+
+    let mut output = vec![0u8; hash.len()];
+    pbkdf2::<Hmac<Sha256>>(password.as_bytes(), &salt, c as usize, &mut output);
+
+    // Be careful here - its important that the comparison be done using a fixed time equality
+    // check. Otherwise an adversary that can measure how long this step takes can learn about the
+    // hashed value which would allow them to mount an offline brute force attack against the
+    // hashed password.
+    Ok(constant_time_eq(&output[..], &hash[..]))
 }

--- a/pbkdf2/tests/lib.rs
+++ b/pbkdf2/tests/lib.rs
@@ -41,3 +41,33 @@ fn rfc6070() {
         assert_eq!(&buf[..n], test.output);
     }
 }
+
+#[test]
+fn test_pbkdf2_simple() {
+    let password = "password";
+
+    let out1 = pbkdf2::pbkdf2_simple(password, 1024).unwrap();
+    let out2 = pbkdf2::pbkdf2_simple(password, 1024).unwrap();
+
+    // This just makes sure that a salt is being applied. It doesn't verify that that salt is
+    // cryptographically strong, however.
+    assert!(out1 != out2);
+
+    match pbkdf2::pbkdf2_check(password, &out1[..]) {
+        Ok(r) => assert!(r),
+        Err(_) => panic!()
+    }
+    match pbkdf2::pbkdf2_check(password, &out2[..]) {
+        Ok(r) => assert!(r),
+        Err(_) => panic!()
+    }
+
+    match pbkdf2::pbkdf2_check("wrong", &out1[..]) {
+        Ok(r) => assert!(!r),
+        Err(_) => panic!()
+    }
+    match pbkdf2::pbkdf2_check("wrong", &out2[..]) {
+        Ok(r) => assert!(!r),
+        Err(_) => panic!()
+    }
+}

--- a/pbkdf2/tests/lib.rs
+++ b/pbkdf2/tests/lib.rs
@@ -4,6 +4,7 @@ extern crate hmac;
 
 use sha1::Sha1;
 use hmac::Hmac;
+use pbkdf2::errors::CheckError;
 
 #[derive(Debug)]
 pub struct Test {
@@ -43,6 +44,7 @@ fn rfc6070() {
 }
 
 #[test]
+#[cfg(feature="include_simple")]
 fn test_pbkdf2_simple() {
     let password = "password";
 
@@ -51,23 +53,11 @@ fn test_pbkdf2_simple() {
 
     // This just makes sure that a salt is being applied. It doesn't verify that that salt is
     // cryptographically strong, however.
-    assert!(out1 != out2);
+    assert_ne!(out1, out2);
 
-    match pbkdf2::pbkdf2_check(password, &out1[..]) {
-        Ok(r) => assert!(r),
-        Err(_) => panic!()
-    }
-    match pbkdf2::pbkdf2_check(password, &out2[..]) {
-        Ok(r) => assert!(r),
-        Err(_) => panic!()
-    }
+    assert_eq!(pbkdf2::pbkdf2_check(password, &out1[..]), Ok(()));
+    assert_eq!(pbkdf2::pbkdf2_check(password, &out2[..]), Ok(()));
 
-    match pbkdf2::pbkdf2_check("wrong", &out1[..]) {
-        Ok(r) => assert!(!r),
-        Err(_) => panic!()
-    }
-    match pbkdf2::pbkdf2_check("wrong", &out2[..]) {
-        Ok(r) => assert!(!r),
-        Err(_) => panic!()
-    }
+    assert_eq!(pbkdf2::pbkdf2_check("wrong", &out1[..]), Err(CheckError::HashMismatch));
+    assert_eq!(pbkdf2::pbkdf2_check("wrong", &out2[..]), Err(CheckError::HashMismatch));
 }


### PR DESCRIPTION
Ported `pbkdf2_simple` and `pbkdf2_check`, and corresponding tests and docs from [`rust-crypto`](https://github.com/DaGenix/rust-crypto/blob/master/src/pbkdf2.rs).