### PR TITLE
Bug in pbkdf2 xor function

### DIFF
--- a/pbkdf2/src/lib.rs
+++ b/pbkdf2/src/lib.rs
@@ -54,10 +54,9 @@ pub use errors::CheckError;
 
 #[inline(always)]
 fn xor(res: &mut [u8], salt: &[u8]) {
-    assert!(salt.len() >= res.len(), "length mismatch in xor");
-    for i in 0..res.len() {
-        res[i] ^= salt[i];
-    }
+    debug_assert!(salt.len() >= res.len(), "length mismatch in xor");
+
+    res.iter_mut().zip(salt.iter()).for_each(|(a, b)| *a ^= b);
 }
 
 #[inline(always)]

--- a/pbkdf2/src/lib.rs
+++ b/pbkdf2/src/lib.rs
@@ -54,7 +54,7 @@ pub use errors::CheckError;
 
 #[inline(always)]
 fn xor(res: &mut [u8], salt: &[u8]) {
-    assert!(salt.len() >= salt.len(), "length mismatch in xor");
+    assert!(salt.len() >= res.len(), "length mismatch in xor");
     for i in 0..res.len() {
         res[i] ^= salt[i];
     }

--- a/pbkdf2/src/lib.rs
+++ b/pbkdf2/src/lib.rs
@@ -245,3 +245,18 @@ pub fn pbkdf2_check(password: &str, hashed_value: &str)
         Err(CheckError::HashMismatch)
     }
 }
+
+
+#[test]
+fn xor_res_salt_ok() {
+    let mut res = [0u8; 32];
+    xor(&mut res, &[0u8; 32]);
+    xor(&mut res, &[0u8; 64]);
+}
+
+#[test]
+#[should_panic]
+fn xor_res_salt_panic() {
+    let mut res = [0u8; 32];
+    xor(&mut res, &[0u8; 16]);
+}


### PR DESCRIPTION
Currently the XOR function checks if the salt lenght is greater than or equal to itself:
```rust
[inline(always)]
fn xor(res: &mut [u8], salt: &[u8]) {
    assert!(salt.len() >= salt.len(), "length mismatch in xor");
    for i in 0..res.len() {
        res[i] ^= salt[i];
    }
}
```
I believe it actually should be checking that it's greater than or equal to `res`. Currently this doesn't show up in tests because the salt value is always passed with an `F::OutputSize` length and `chunk` will always be <= `F::OutputSize`, but I think this should be fixed in case the implementation changes in the future. I've checked the versions available on crates.io(0.1.0, 0.2.0, 0.2.1), too see if they all are implemented in a way that `chunk` will never be greater in length than a salt value passed. I found no problems with these three versions, but they all have this exact `assert!` line. I have also added regression tests to this PR.