### PR TITLE
Add scrypt documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rust:
   - nightly
 matrix:
   include:
-    script: cd scrypt; cargo test --verbose --no-default-features
+    script: cd scrypt; cargo test --tests --verbose --no-default-features
   allow_failures:
     - rust: nightly
 script: cargo test --verbose --all

--- a/pbkdf2/src/lib.rs
+++ b/pbkdf2/src/lib.rs
@@ -1,11 +1,11 @@
-//! This crate implements the Scrypt key derivation function as specified
+//! This crate implements the PBKDF2 key derivation function as specified
 //! in [RFC 2898](https://tools.ietf.org/html/rfc2898).
 //!
 //! If you are not using convinience functions `pbkdf2_check` and `pbkdf2_simple`
 //! it's recommended to disable `pbkdf2` default features in your `Cargo.toml`:
 //! ```toml
 //! [dependencies]
-//! scrypt = { version = "0.1", default-features = false }
+//! pbkdf2 = { version = "0.2", default-features = false }
 //! ```
 #![cfg_attr(not(feature = "include_simple"), no_std)]
 #![cfg_attr(feature = "cargo-clippy", allow(inline_always))]

--- a/scrypt/src/errors.rs
+++ b/scrypt/src/errors.rs
@@ -1,15 +1,20 @@
 use std::{fmt, error};
 
+/// `scrypt()` error
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct InvalidOutputLen;
 
+/// `ScryptParams` error
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct InvalidParams;
 
+/// `scrypt_check` error
 #[cfg(feature="include_simple")]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum CheckError {
+    /// Password hash mismatch, e.g. due to the incorrect password.
     HashMismatch,
+    /// Invalid format of the hash string.
     InvalidFormat,
 }
 

--- a/scrypt/src/lib.rs
+++ b/scrypt/src/lib.rs
@@ -42,6 +42,7 @@ use rand::{OsRng, RngCore};
 
 mod params;
 mod romix;
+/// Errors for `scrypt` operations.
 pub mod errors;
 
 pub use params::ScryptParams;

--- a/scrypt/src/lib.rs
+++ b/scrypt/src/lib.rs
@@ -15,6 +15,22 @@
 //! \[1\] - [C. Percival. Stronger Key Derivation Via Sequential
 //! Memory-Hard Functions](http://www.tarsnap.com/scrypt/scrypt.pdf)
 //!
+//!
+//! # Usage
+//!
+//! ```
+//! extern crate scrypt;
+//!
+//! use scrypt::{ScryptParams, scrypt_simple, scrypt_check};
+//!
+//! // First setup the ScryptParams arguments with:
+//! // r = 8, p = 1, n = 32768 (log2(n) = 15)
+//! let params = ScryptParams::new(15, 8, 1).unwrap();
+//! // Hash the password for storage
+//! let hashed_password = scrypt_simple("Not so secure password", &params).unwrap();
+//! // Verifying a stored password
+//! assert!(scrypt_check("Not so secure password", &hashed_password).is_ok());
+//! ```
 extern crate sha2;
 extern crate pbkdf2;
 extern crate hmac;

--- a/scrypt/src/params.rs
+++ b/scrypt/src/params.rs
@@ -18,6 +18,10 @@ impl ScryptParams {
     /// - `log_n` - The log2 of the Scrypt parameter `N`
     /// - `r` - The Scrypt parameter `r`
     /// - `p` - The Scrypt parameter `p`
+    /// # Conditions
+    /// - `log_n` must be less than `64`
+    /// - `r` must be greater than `0` and less than or equal to `4294967295`
+    /// - `p` must be greater than `0` and less than `4294967295`
     pub fn new(log_n: u8, r: u32, p: u32) -> Result<ScryptParams, InvalidParams> {
         let cond1 = (log_n as usize) < size_of::<usize>() * 8;
         let cond2 = size_of::<usize>() >= size_of::<u32>();

--- a/scrypt/src/params.rs
+++ b/scrypt/src/params.rs
@@ -22,6 +22,10 @@ impl ScryptParams {
     /// - `log_n` must be less than `64`
     /// - `r` must be greater than `0` and less than or equal to `4294967295`
     /// - `p` must be greater than `0` and less than `4294967295`
+    /// # Recommended values sufficient for most use-cases
+    /// - `log_n = 15` (`n = 32768`)
+    /// - `r = 8`
+    /// - `p = 1`
     pub fn new(log_n: u8, r: u32, p: u32) -> Result<ScryptParams, InvalidParams> {
         let cond1 = (log_n as usize) < size_of::<usize>() * 8;
         let cond2 = size_of::<usize>() >= size_of::<u32>();


### PR DESCRIPTION
Fixing #3. I've also corrected some docs in `pbkdf2` and added a "Recommended values" section to `ScryptParams`. These recommended values have been taken from the [golang scrypt package](https://godoc.org/golang.org/x/crypto/scrypt).