### PR TITLE
Don't use rand::OsRng when compiling for wasm

### DIFF
--- a/pbkdf2/src/lib.rs
+++ b/pbkdf2/src/lib.rs
@@ -38,7 +38,7 @@ use std::io;
 
 #[cfg(feature="include_simple")]
 use constant_time_eq::constant_time_eq;
-#[cfg(feature="include_simple")]
+#[cfg(all(not(target_arch="wasm32"), feature="include_simple"))]
 use rand::{OsRng, RngCore};
 #[cfg(feature="include_simple")]
 use hmac::Hmac;
@@ -135,7 +135,7 @@ pub fn pbkdf2<F>(password: &[u8], salt: &[u8], c: usize, res: &mut [u8])
 ///
 /// * `password` - The password to process
 /// * `c` - The iteration count
-#[cfg(feature="include_simple")]
+#[cfg(all(not(target_arch="wasm32"), feature="include_simple"))]
 pub fn pbkdf2_simple(password: &str, c: u32) -> io::Result<String> {
     let mut rng = OsRng::new()?;
 


### PR DESCRIPTION
When compiling for `wasm32-unknown-unknown` it will abort because of `rand::OsRng`.

```bash
error[E0432]: unresolved import `rand::OsRng`
  --> password-hashing/pbkdf2/src/lib.rs:42:12
   |
42 | use rand::{OsRng, RngCore};
   |            ^^^^^ no `OsRng` in the root
```

Since I only need `pbkdf2` and not `pbkdf2_simple`, which relies on `rand::OsRng`, I've just "configed" it and the `use` out for wasm.

However, I'm not sure if this is an actual fix or just a workaround for something else that needs to get fixed in order for this to work with wasm.
