### PR TITLE
Use subtle v2

### DIFF
--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -18,7 +18,7 @@ base64 = { version = "0.9", optional = true }
 rand = { version = "0.5", optional = true }
 hmac = { version = "0.7", optional = true }
 sha2 = { version = "0.8", optional = true }
-subtle = { version = "1", default-features = false , optional = true }
+subtle = { version = "2", default-features = false , optional = true }
 
 [dev-dependencies]
 hmac = "0.7"

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -16,7 +16,7 @@ hmac = "0.7"
 byte-tools = "0.3"
 byteorder = { version = "1", default-features = false }
 
-subtle = { version = "1", default-features = false , optional = true }
+subtle = { version = "2", default-features = false , optional = true }
 base64 = { version = "0.9", optional = true }
 rand = { version = "0.5", optional = true }
 


### PR DESCRIPTION
Hi, we released version 2 of `subtle` (context: https://github.com/RustCrypto/traits/pull/33#issue-238854180 ).

As far as I can tell, `subtle` is only used for `ConstantTimeEq`, which is only used internally, so this dependency upgrade will not be a semver breaking change.