### PR TITLE
Byteorder removed

### DIFF
--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -11,8 +11,6 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 crypto-mac = "0.7"
-byteorder = { version = "1", default-features = false }
-
 rayon = { version = "1", optional = true }
 base64 = { version = "0.9", optional = true }
 rand = { version = "0.5", optional = true }

--- a/pbkdf2/src/lib.rs
+++ b/pbkdf2/src/lib.rs
@@ -12,7 +12,6 @@
     "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 #![cfg_attr(feature = "cargo-clippy", allow(inline_always))]
 extern crate crypto_mac;
-extern crate byteorder;
 
 #[cfg(feature="parallel")]
 extern crate rayon;
@@ -44,7 +43,6 @@ use rayon::prelude::*;
 
 use crypto_mac::Mac;
 use crypto_mac::generic_array::typenum::Unsigned;
-use byteorder::{ByteOrder, BigEndian};
 
 #[inline(always)]
 fn xor(res: &mut [u8], salt: &[u8]) {
@@ -64,7 +62,7 @@ fn pbkdf2_body<F>(i: usize, chunk: &mut [u8], prf: &F, salt: &[u8], c: usize)
         prfc.input(salt);
 
         let mut buf = [0u8; 4];
-        BigEndian::write_u32(&mut buf, (i + 1) as u32);
+        (&mut buf[0..4]).copy_from_slice(&((i + 1) as u32).to_be_bytes());
         prfc.input(&buf);
 
         let salt = prfc.result().code();

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -14,8 +14,6 @@ sha2 = { version = "0.8", default-features = false }
 pbkdf2 = { version = "0.3", default-features = false }
 hmac = "0.7"
 byte-tools = "0.3"
-byteorder = { version = "1", default-features = false }
-
 subtle = { version = "2", default-features = false , optional = true }
 base64 = { version = "0.9", optional = true }
 rand = { version = "0.5", optional = true }

--- a/scrypt/src/lib.rs
+++ b/scrypt/src/lib.rs
@@ -38,7 +38,6 @@
 extern crate sha2;
 extern crate pbkdf2;
 extern crate hmac;
-extern crate byteorder;
 extern crate byte_tools;
 #[cfg(feature="include_simple")]
 extern crate subtle;


### PR DESCRIPTION
This removes the `byteorder`-dependency, which is not strictly needed since Rust 1.32. Dropping a dependency is worth the change IMHO.