### PR TITLE
Rename `*result*` to `finalize`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,7 @@ block-buffer = { git = "https://github.com/RustCrypto/utils" }
 crypto-mac = { git = "https://github.com/RustCrypto/traits" }
 digest = { git = "https://github.com/RustCrypto/traits" }
 hmac = { git = "https://github.com/RustCrypto/MACs" }
+salsa20 = { git = "https://github.com/RustCrypto/stream-ciphers" }
 sha-1 = { git = "https://github.com/RustCrypto/hashes" }
 sha2 = { git = "https://github.com/RustCrypto/hashes" }
+stream-cipher = { git = "https://github.com/RustCrypto/traits" }

--- a/pbkdf2/src/lib.rs
+++ b/pbkdf2/src/lib.rs
@@ -11,12 +11,6 @@
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 #![cfg_attr(feature = "cargo-clippy", allow(inline_always))]
 
-#[cfg(feature = "parallel")]
-extern crate rayon;
-
-#[cfg(feature = "include_simple")]
-extern crate base64;
-
 #[cfg(feature = "include_simple")]
 #[macro_use]
 extern crate std;
@@ -60,7 +54,7 @@ where
         BigEndian::write_u32(&mut buf, (i + 1) as u32);
         prfc.update(&buf);
 
-        let salt = prfc.result().into_bytes();
+        let salt = prfc.finalize().into_bytes();
         xor(chunk, &salt);
         salt
     };
@@ -68,7 +62,7 @@ where
     for _ in 1..c {
         let mut prfc = prf.clone();
         prfc.update(&salt);
-        salt = prfc.result().into_bytes();
+        salt = prfc.finalize().into_bytes();
 
         xor(chunk, &salt);
     }

--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -11,15 +11,15 @@ categories = ["cryptography"]
 edition = "2018"
 
 [dependencies]
-sha2 = { version = "= 0.9.0-pre", default-features = false }
-pbkdf2 = { version = "= 0.4.0-pre", default-features = false, path = "../pbkdf2" }
-hmac = "= 0.8.0-pre"
+base64 = { version = "0.9", optional = true }
 byte-tools = "0.3"
 byteorder = { version = "1", default-features = false }
-
-subtle = { version = "2", default-features = false , optional = true }
-base64 = { version = "0.9", optional = true }
+hmac = "= 0.8.0-pre"
+pbkdf2 = { version = "= 0.4.0-pre", default-features = false, path = "../pbkdf2" }
 rand = { version = "0.5", optional = true }
+sha2 = { version = "= 0.9.0-pre", default-features = false }
+salsa20 = "= 0.5.0-pre"
+subtle = { version = "2", default-features = false , optional = true }
 
 [features]
 default = ["include_simple"]


### PR DESCRIPTION
Implements the API changes from:

https://github.com/RustCrypto/traits/pull/161

The `hmac` crate now uses `update` and `finalize` nomenclature ala the Initialize-Update-Finalize (IUF) interface naming scheme.