### PR TITLE
pbkdf2: bump `rand` dependency to v0.7

### DIFF
--- a/pbkdf2/Cargo.toml
+++ b/pbkdf2/Cargo.toml
@@ -16,7 +16,7 @@ byteorder = { version = "1", default-features = false }
 
 rayon = { version = "1", optional = true }
 base64 = { version = "0.9", optional = true }
-rand = { version = "0.5", optional = true }
+rand = { version = "0.7", optional = true }
 hmac = { version = "0.8", optional = true }
 sha2 = { version = "0.9", optional = true }
 subtle = { version = "2", default-features = false , optional = true }

--- a/pbkdf2/src/simple.rs
+++ b/pbkdf2/src/simple.rs
@@ -6,7 +6,8 @@ use std::string::ToString;
 use crate::errors::CheckError;
 use base64;
 use hmac::Hmac;
-use rand::{OsRng, RngCore};
+use rand::RngCore;
+use rand::rngs::OsRng;
 use sha2::Sha256;
 use subtle::ConstantTimeEq;
 
@@ -35,11 +36,9 @@ use byteorder::{BigEndian, ByteOrder};
 /// * `password` - The password to process
 /// * `c` - The iteration count
 pub fn pbkdf2_simple(password: &str, c: u32) -> io::Result<String> {
-    let mut rng = OsRng::new()?;
-
     // 128-bit salt
     let mut salt = [0u8; 16];
-    rng.try_fill_bytes(&mut salt)?;
+    OsRng.try_fill_bytes(&mut salt)?;
 
     // 256-bit derived key
     let mut dk = [0u8; 32];


### PR DESCRIPTION
Closes #17 and #18 