### PR TITLE
scrypt: `std` feature

### DIFF
--- a/scrypt/Cargo.toml
+++ b/scrypt/Cargo.toml
@@ -22,7 +22,8 @@ subtle = { version = "2", default-features = false , optional = true }
 
 [features]
 default = ["include_simple"]
-include_simple = ["rand", "base64", "subtle"]
+include_simple = ["rand", "base64", "subtle", "std"]
+std = []
 
 [badges]
 travis-ci = { repository = "RustCrypto/password-hashing" }

--- a/scrypt/src/errors.rs
+++ b/scrypt/src/errors.rs
@@ -1,4 +1,4 @@
-use std::{error, fmt};
+use core::fmt;
 
 /// `scrypt()` error
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -24,11 +24,8 @@ impl fmt::Display for InvalidOutputLen {
     }
 }
 
-impl error::Error for InvalidOutputLen {
-    fn description(&self) -> &str {
-        "invalid output buffer length"
-    }
-}
+#[cfg(feature = "std")]
+impl std::error::Error for InvalidOutputLen {}
 
 impl fmt::Display for InvalidParams {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -36,11 +33,8 @@ impl fmt::Display for InvalidParams {
     }
 }
 
-impl error::Error for InvalidParams {
-    fn description(&self) -> &str {
-        "invalid scrypt parameters"
-    }
-}
+#[cfg(feature = "std")]
+impl std::error::Error for InvalidParams {}
 
 #[cfg(feature = "include_simple")]
 impl fmt::Display for CheckError {
@@ -52,12 +46,5 @@ impl fmt::Display for CheckError {
     }
 }
 
-#[cfg(feature = "include_simple")]
-impl error::Error for CheckError {
-    fn description(&self) -> &str {
-        match *self {
-            CheckError::HashMismatch => "password hash mismatch",
-            CheckError::InvalidFormat => "invalid `hashed_value` format",
-        }
-    }
-}
+#[cfg(all(feature = "include_simple", feature = "std"))]
+impl std::error::Error for CheckError {}

--- a/scrypt/src/lib.rs
+++ b/scrypt/src/lib.rs
@@ -33,10 +33,15 @@
 //! # References
 //! \[1\] - [C. Percival. Stronger Key Derivation Via Sequential
 //! Memory-Hard Functions](http://www.tarsnap.com/scrypt/scrypt.pdf)
+
+#![no_std]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustCrypto/meta/master/logo_small.png")]
 
-#[cfg(feature = "include_simple")]
-extern crate base64;
+#[macro_use]
+extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
 
 use hmac::Hmac;
 use pbkdf2::pbkdf2;

--- a/scrypt/src/params.rs
+++ b/scrypt/src/params.rs
@@ -1,5 +1,4 @@
-use std::mem::size_of;
-use std::usize;
+use core::{mem::size_of, usize};
 
 use crate::errors::InvalidParams;
 

--- a/scrypt/src/simple.rs
+++ b/scrypt/src/simple.rs
@@ -1,14 +1,14 @@
-#![cfg(feature="include_simple")]
 use std::io;
 
 use super::scrypt;
 use crate::errors::CheckError;
 use crate::ScryptParams;
 
+use alloc::string::String;
 use subtle::ConstantTimeEq;
-// TODO: replace with rand core and seprate os-rng crate
 use base64;
 use byteorder::{ByteOrder, LittleEndian};
+// TODO: replace with rand_core
 use rand::{OsRng, RngCore};
 
 /// `scrypt_simple` is a helper function that should be sufficient for the


### PR DESCRIPTION
Makes `std` optional, relying on `alloc` for heap-allocated data structures and `core` for everything else.